### PR TITLE
added SSL certificate management

### DIFF
--- a/terraform/modules/aws-certificate/main.tf
+++ b/terraform/modules/aws-certificate/main.tf
@@ -1,0 +1,8 @@
+
+# create AWS resource of that certificate
+resource "aws_acm_certificate" "this" {
+  private_key      = var.private_key_pem
+  certificate_body = var.cert_pem
+}
+
+

--- a/terraform/modules/aws-certificate/outputs.tf
+++ b/terraform/modules/aws-certificate/outputs.tf
@@ -1,0 +1,5 @@
+output "id" {
+  description = "The ID of the certificate"
+  value       = concat(aws_acm_certificate.this.*.id, [""])[0]
+}
+

--- a/terraform/modules/aws-certificate/variables.tf
+++ b/terraform/modules/aws-certificate/variables.tf
@@ -1,0 +1,10 @@
+variable "private_key_pem" {
+  description = "The private key content"
+  type        = string
+}
+
+variable "cert_pem" {
+  description = "The Certificate content"
+  type        = string
+}
+

--- a/terraform/modules/route-record/main.tf
+++ b/terraform/modules/route-record/main.tf
@@ -6,7 +6,8 @@ locals {
 resource "aws_route53_record" "this" {
   for_each = local.recordsets
 
-  zone_id = var.zone_id
+  zone_id         = var.zone_id
+  allow_overwrite = var.allow_overwrite
 
   name    = each.value.name != "" ? "${each.value.name}.${var.zone_name}" : var.zone_name
   type    = each.value.type

--- a/terraform/modules/route-record/variables.tf
+++ b/terraform/modules/route-record/variables.tf
@@ -25,3 +25,9 @@ variable "records" {
   type        = any
   default     = []
 }
+
+variable "allow_overwrite" {
+  description = "Whether to overwrite existing records"
+  type	      = bool
+  default     = true
+}

--- a/terraform/modules/tls-certificate/main.tf
+++ b/terraform/modules/tls-certificate/main.tf
@@ -1,0 +1,23 @@
+
+
+# make it a self signed one for short duration
+resource "tls_self_signed_cert" "this" {
+    key_algorithm   = "RSA"
+
+    private_key_pem = var.private_key_pem
+
+    subject {
+	common_name  = var.dns_zone
+        organization = var.organization
+    }
+
+    validity_period_hours = var.validity_hours
+
+    allowed_uses = [
+	"key_encipherment",
+        "digital_signature",
+	"server_auth",
+    ]
+}
+
+

--- a/terraform/modules/tls-certificate/outputs.tf
+++ b/terraform/modules/tls-certificate/outputs.tf
@@ -1,0 +1,5 @@
+output "cert_pem" {
+  description = "The PEM of the certificate"
+  value       = concat(tls_self_signed_cert.this.*.cert_pem, [""])[0]
+}
+

--- a/terraform/modules/tls-certificate/variables.tf
+++ b/terraform/modules/tls-certificate/variables.tf
@@ -1,0 +1,22 @@
+
+
+variable private_key_pem {
+    description = "Content of the PEM part of the certificate"
+    type = string
+}
+
+variable dns_zone {
+    description = "the Domain-Name that the certificate is associated to"
+    type = string
+}
+
+variable organization {
+    description = "Organzation description"
+    type = string
+}
+
+variable validity_hours {
+    description = "How long to the certificate is to be valid for (hours)"
+    type = number
+    default = 12
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -7,7 +7,7 @@ variable "ami_image" {
 }
 
 variable "ssh_instance_user" {
-    description = "The user to login via SSH"
+    description = "The user to login via SSH to run Ansible"
     default = "ec2-user"
     type = string
 }
@@ -26,8 +26,7 @@ variable "ssl_cert" {
 
 variable "ssh_access_permit" {
     description = "Allow SSH access from these networks"
-#    default = ["86.25.180.0/24"]
-    default = ["0.0.0.0/0"]
+    default = ["86.25.180.0/24"]
     type = list(string)
 }
 


### PR DESCRIPTION
the SSL certificate for the Load-Balancer is now auto generated and issued for a validity of 12 hours. It's bound to the CNAME part of the project and domain (i.e. www.<domain.com>, www2.<domain.com>...)